### PR TITLE
uninitialized value warning fix

### DIFF
--- a/lib/RDF/RDFa/Generator/HTML/Pretty.pm
+++ b/lib/RDF/RDFa/Generator/HTML/Pretty.pm
@@ -212,7 +212,7 @@ sub _resource_statements
 		{
 			$DD->setAttribute('property',  $self->_make_curie($st->predicate->uri, $prefixes));
 			$DD->setAttribute('class', 'plain-literal');
-			$DD->setAttribute('xml:lang',  $st->object->literal_value_language);
+			$DD->setAttribute('xml:lang',  ''.$st->object->literal_value_language);
 			$DD->appendTextNode(encode_utf8($st->object->literal_value));
 		}
 		elsif ($self->{'safe_xml_literals'}

--- a/t/uninit_lang_warning.t
+++ b/t/uninit_lang_warning.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Output;
+
+use RDF::Trine qw(blank iri literal);
+use RDF::RDFa::Generator;
+
+my $t = RDF::Trine::Statement::Quad->new(
+	blank('x'),
+	iri('http://example.org/p'),
+	literal(3),
+	iri('http://example.org/graph1'),
+);
+
+my $model = RDF::Trine::Model->new(); 
+$model->add_statement($t);
+
+my $pretty = RDF::RDFa::Generator::HTML::Pretty->new();
+
+stderr_unlike sub {
+	print $pretty->create_document($model);
+}, qr/Use of uninitialized value in subroutine entry/, 'pretty - no uninitalized value warning ok';
+
+my $head = RDF::RDFa::Generator::HTML::Head->new();
+
+stderr_unlike sub {
+	print $head->create_document($model);
+}, qr/Use of uninitialized value in subroutine entry/, 'head - no uninitalized value warning ok';
+
+done_testing();


### PR DESCRIPTION
Prevent XML::LibXML::Element::setAttribute from complaining about uninitialized value.
Same fix that was done in: RDF::RDFa::Generator::HTML::Head

Zoran
